### PR TITLE
Removing syntax constructs unsupported in rspec 3

### DIFF
--- a/spec/occi/core/action_instance_spec.rb
+++ b/spec/occi/core/action_instance_spec.rb
@@ -41,7 +41,7 @@ module Occi
         end
 
         it 'does not fail without attributes' do
-          expect { Occi::Core::ActionInstance.new action, nil }.not_to raise_error(ArgumentError)
+          expect { Occi::Core::ActionInstance.new action, nil }.not_to raise_error
         end
 
         it 'does not fail with an Occi::Core::Action instance' do
@@ -61,7 +61,7 @@ module Occi
         end
 
         it 'does not fail with un-convertable attribute values' do
-          expect { Occi::Core::ActionInstance.new action, attributes_unconvertable}.not_to raise_error(ArgumentError)
+          expect { Occi::Core::ActionInstance.new action, attributes_unconvertable}.not_to raise_error
         end
       end
 
@@ -292,14 +292,14 @@ X-OCCI-Attribute: org.opennebula.network.id=1|
       context '#empty?' do
 
         it 'returns false for a new instance with defaults' do
-          expect(ai.empty?).to be_false
+          expect(ai.empty?).to be false
         end
 
         it 'returns true for an instance without an action' do
           ai_changed = ai.clone
           ai_changed.action = nil
 
-          expect(ai_changed.empty?).to be_true
+          expect(ai_changed.empty?).to be true
         end
 
         it 'returns true for an instance with an empty action' do
@@ -307,7 +307,7 @@ X-OCCI-Attribute: org.opennebula.network.id=1|
           ai_changed.action = Occi::Core::Action.new
           ai_changed.action.term = nil
 
-          expect(ai_changed.empty?).to be_true
+          expect(ai_changed.empty?).to be true
         end
 
       end

--- a/spec/occi/core/attributes_spec.rb
+++ b/spec/occi/core/attributes_spec.rb
@@ -19,7 +19,7 @@ module Occi
         end
 
         it 'accepts keys with underscores in other positions' do
-          expect{ attributes['t_est']={} }.to_not raise_error(Occi::Errors::AttributeNameInvalidError)
+          expect{ attributes['t_est']={} }.to_not raise_error
         end
       end
 

--- a/spec/occi/core/category_spec.rb
+++ b/spec/occi/core/category_spec.rb
@@ -190,21 +190,21 @@ module Occi
       context '#empty?' do
 
         it 'returns false for a new instance with defaults' do
-          expect(category.empty?).to be_false
+          expect(category.empty?).to be false
         end
 
         it 'returns true for an instance without a term' do
           cat = category.clone
           cat.term = nil
 
-          expect(cat.empty?).to be_true
+          expect(cat.empty?).to be true
         end
 
         it 'returns true for an instance without a scheme' do
           cat = category.clone
           cat.scheme = nil
 
-          expect(cat.empty?).to be_true
+          expect(cat.empty?).to be true
         end
 
       end

--- a/spec/occi/core/entity_spec.rb
+++ b/spec/occi/core/entity_spec.rb
@@ -350,21 +350,21 @@ Link: </TestLoc/1?action=testaction>;rel="http://schemas.ogf.org/occi/core/entit
       context '#empty?' do
 
         it 'returns false for a new instance with defaults' do
-          expect(entity.empty?).to be_false
+          expect(entity.empty?).to be false
         end
 
         it 'returns true for an instance without a kind' do
           ent = entity.clone
           ent.kind = nil
 
-          expect(ent.empty?).to be_true
+          expect(ent.empty?).to be true
         end
 
         it 'returns true for an instance without an identifier' do
           ent = entity.clone
           ent.id = nil
 
-          expect(ent.empty?).to be_true
+          expect(ent.empty?).to be true
         end
 
       end

--- a/spec/occi/core/resource_spec.rb
+++ b/spec/occi/core/resource_spec.rb
@@ -9,7 +9,7 @@ module Occi
       
       context '#link' do
         it "creates the appropriate No. of links" do
-          expect(resource.links).to have(1).link
+          expect(resource.links.count).to eq 1
         end
 
         it "has the correct kind" do

--- a/spec/occi/infrastructure/compute_spec.rb
+++ b/spec/occi/infrastructure/compute_spec.rb
@@ -17,7 +17,7 @@ module Occi
         context '#storagelink' do
           it "creates a single storagelink" do
             compute.storagelink target
-            expect(compute.links).to have(1).link
+            expect(compute.links.count).to eq 1
           end
 
           it "creates a storagelink to a storage resource" do
@@ -70,7 +70,7 @@ module Occi
         context '#networkinterface' do
           it "creates a single networkinterface" do
             compute.networkinterface target
-            expect(compute.links).to have(1).link
+            expect(compute.links.count).to eq 1
           end
 
           it "creates a networkinterface to a storage resource" do

--- a/spec/occi/parser/text_spec.rb
+++ b/spec/occi/parser/text_spec.rb
@@ -33,10 +33,10 @@ module Occi
           category_string = 'Category: restart;scheme="http://schemas.ogf.org/occi/infrastructure/compute/action#";class="action";title="Restart Compute instance";attributes="method{required} test{immutable}"'
           category = Occi::Parser::Text.category category_string
 
-          expect(category.attributes['method'].required).to be_true
-          expect(category.attributes['method'].mutable).to be_true
-          expect(category.attributes['test'].required).to be_false
-          expect(category.attributes['test'].mutable).to be_false
+          expect(category.attributes['method'].required).to be true
+          expect(category.attributes['method'].mutable).to be true
+          expect(category.attributes['test'].required).to be false
+          expect(category.attributes['test'].mutable).to be false
         end
 
         it 'parses attributes correctly' do


### PR DESCRIPTION
- be_false/be_true matchers replaced
- When expecting block not to throw expection, arguments cannot be used. I.e., any expection violates the expectation.
- have() matcher unsupported. Replaced with .count() method.
