### PR TITLE
[Deps] Updated dep. specs and testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1
   - ruby-head
   - jruby-19mode
   - jruby-head
@@ -26,9 +26,9 @@ matrix:
       jdk: openjdk7
     - rvm: 2.0.0
       jdk: oraclejdk7
-    - rvm: 2.1.0
+    - rvm: 2.1
       jdk: openjdk7
-    - rvm: 2.1.0
+    - rvm: 2.1
       jdk: oraclejdk7
     - rvm: ruby-head
       jdk: openjdk7
@@ -42,3 +42,4 @@ branches:
     - 4.0.x
     - 4.1.x
     - 4.2.x
+    - 4.3.x

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ group :development do
   gem 'simplecov'
   gem 'yard'
   gem 'yard-rspec'
-  gem 'debugger', :platforms => :ruby
+  gem 'debugger', :platforms => :ruby if RUBY_VERSION == '1.9.3'
 end


### PR DESCRIPTION
Removing the 'debugger' gem from required dependencies. It's not compatible with many Ruby versions and breaks testing (unnecessarily).
