### PR TITLE
Fixed attribute defaulting and validation

### DIFF
--- a/lib/occi/core/attributes.rb
+++ b/lib/occi/core/attributes.rb
@@ -325,22 +325,24 @@ module Occi
       end
 
       def add_missing_attributes(attributes, definitions, set_defaults)
-        attributes ||= Occi::Core::Attributes.new
-
         definitions.each_key do |key|
           next if key =~ /^_/
 
           if definitions[key].kind_of? Occi::Core::Attributes
+            attributes[key] = Occi::Core::Attributes.new if attributes[key].nil?
             add_missing_attributes(attributes[key], definitions[key], set_defaults)
           elsif attributes[key].nil?
-
             if definitions[key].default.nil?
               raise Occi::Errors::AttributeMissingError,
                     "Required attribute #{key} not specified" if definitions[key].required
-            else
-              attributes[key] = definitions[key].default if definitions[key].required || set_defaults
+            elsif definitions[key].required || set_defaults
+              attributes[key] = definitions[key]
+              attributes[key] = definitions[key].default
             end
-
+          else
+            old_val = attributes[key]
+            attributes[key] = definitions[key]
+            attributes[key] = old_val
           end
         end
       end

--- a/lib/occi/version.rb
+++ b/lib/occi/version.rb
@@ -1,3 +1,3 @@
 module Occi
-  VERSION = "4.3.4" unless defined?(::Occi::VERSION)
+  VERSION = "4.3.5" unless defined?(::Occi::VERSION)
 end

--- a/occi-core.gemspec
+++ b/occi-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'json', '>= 1.8.1', '< 3'
-  gem.add_dependency 'hashie', '>= 3.3.1', '< 4'
+  gem.add_dependency 'hashie', '>= 3.3.1', '< 3.5'
   gem.add_dependency 'uuidtools', '>= 2.1.3', '< 3'
   gem.add_dependency 'activesupport', '>= 4.0.0', '< 6'
   gem.add_dependency 'settingslogic', '>= 2.0.9', '< 3'


### PR DESCRIPTION
When validating attributes, local properties must be overwritten by properties from definitions __before__ attempting to set defaults.