### PR TITLE
Fixed parser for non-model category collections

### DIFF
--- a/examples/rendering/categories.json
+++ b/examples/rendering/categories.json
@@ -1,78 +1,8 @@
 {
   "mixins": [
-    {
-      "applies": [
-        "http://schemas.ogf.org/occi/infrastructure#network"
-      ],
-      "attributes": {
-        "occi.network.address": {
-          "description": "IP address (v4 or v6) assigned to this instance.",
-          "mutable": true,
-          "required": false,
-          "type": "string"
-        },
-        "occi.network.allocation": {
-          "default": "static",
-          "description": "Network address allocation mechanism.",
-          "mutable": true,
-          "pattern": "(?-mix:^(dynamic|static)$)",
-          "required": false,
-          "type": "string"
-        },
-        "occi.network.gateway": {
-          "description": "IP address (v4 or v6) of the pre-configured gateway.",
-          "mutable": true,
-          "required": false,
-          "type": "string"
-        }
-      },
-      "location": "/mixin/ipnetwork/",
-      "scheme": "http://schemas.ogf.org/occi/infrastructure/network#",
-      "term": "ipnetwork",
-      "title": "OCCI IP Network mixin"
-    },
-    {
-      "applies": [
-        "http://schemas.ogf.org/occi/infrastructure#networkinterface"
-      ],
-      "attributes": {
-        "occi.networkinterface.address": {
-          "description": "IP address (v4 or v6) assigned to this instance.",
-          "mutable": true,
-          "required": false,
-          "type": "string"
-        },
-        "occi.networkinterface.allocation": {
-          "default": "static",
-          "description": "Network address allocation mechanism.",
-          "mutable": true,
-          "pattern": "(?-mix:^(dynamic|static)$)",
-          "required": false,
-          "type": "string"
-        },
-        "occi.networkinterface.gateway": {
-          "description": "IP address (v4 or v6) of the pre-configured gateway.",
-          "mutable": true,
-          "required": false,
-          "type": "string"
-        }
-      },
-      "location": "/mixin/ipnetworkinterface/",
-      "scheme": "http://schemas.ogf.org/occi/infrastructure/networkinterface#",
-      "term": "ipnetworkinterface",
-      "title": "OCCI IP NetworkInterface mixin"
-    },
-    {
-      "location": "/mixin/os_tpl/",
-      "scheme": "http://schemas.ogf.org/occi/infrastructure#",
-      "term": "os_tpl",
-      "title": "OS or Appliance template (parent mixin)"
-    },
-    {
-      "location": "/mixin/resource_tpl/",
-      "scheme": "http://schemas.ogf.org/occi/infrastructure#",
-      "term": "resource_tpl",
-      "title": "Resource template providing flavor/sizing information (parent mixin)"
-    }
+    "http://schemas.ogf.org/occi/infrastructure/network#ipnetwork",
+    "http://schemas.ogf.org/occi/infrastructure/networkinterface#ipnetworkinterface",
+    "http://schemas.ogf.org/occi/infrastructure#os_tpl",
+    "http://schemas.ogf.org/occi/infrastructure#resource_tpl"
   ]
 }

--- a/examples/rendering/categories.txt
+++ b/examples/rendering/categories.txt
@@ -1,4 +1,4 @@
-Category: resource_tpl;scheme="http://schemas.ogf.org/occi/infrastructure#";class="mixin";title="resource template";location="/mixin/resource_tpl/"
-Category: os_tpl;scheme="http://schemas.ogf.org/occi/infrastructure#";class="mixin";title="operating system template";location="/mixin/os_tpl/"
-Category: ipnetwork;scheme="http://schemas.ogf.org/occi/infrastructure/network#";class="mixin";title="IP network mixin";location="/mixin/ipnetwork/";attributes="occi.network.address occi.network.gateway occi.network.allocation"
-Category: ipnetworkinterface;scheme="http://schemas.ogf.org/occi/infrastructure/networkinterface#";class="mixin";title="IP network interface mixin";location="/mixin/ipnetworkinterface/";attributes="occi.networkinterface.address occi.networkinterface.gateway occi.networkinterface.allocation"
+Category: resource_tpl;scheme="http://schemas.ogf.org/occi/infrastructure#";class="mixin"
+Category: os_tpl;scheme="http://schemas.ogf.org/occi/infrastructure#";class="mixin"
+Category: ipnetwork;scheme="http://schemas.ogf.org/occi/infrastructure/network#";class="mixin"
+Category: ipnetworkinterface;scheme="http://schemas.ogf.org/occi/infrastructure/networkinterface#";class="mixin"

--- a/lib/occi/core/parsers/json/category.rb
+++ b/lib/occi/core/parsers/json/category.rb
@@ -33,13 +33,10 @@ module Occi
             #
             # @param body [String] JSON body for parsing
             # @param model [Occi::Core::Model] model with existing categories
-            # @param full [Boolean] dereference categories
             # @return [Occi::Core::Model] model with all known category instances
-            def json(body, model, full = true)
+            def json(body, model)
               parsed = raw_hash(body)
-
               instantiate_hashes! parsed, model
-              return model unless full
 
               raw_categories = [parsed[:kinds], parsed[:mixins]].flatten.compact
               dereference_identifiers! model.categories, raw_categories

--- a/lib/occi/core/parsers/json/validator.rb
+++ b/lib/occi/core/parsers/json/validator.rb
@@ -27,8 +27,23 @@ module Occi
             end
 
             # :nodoc:
+            def validate_locations!(json)
+              validate! json, :locations
+            end
+
+            # :nodoc:
+            def validate_category_identifiers!(json)
+              validate! json, :'category-identifiers'
+            end
+
+            # :nodoc:
             def validate_model!(json)
               validate! json, :model
+            end
+
+            # :nodoc:
+            def validate_action_instance!(json)
+              validate! json, :'action-instance'
             end
 
             # :nodoc:
@@ -42,33 +57,8 @@ module Occi
             end
 
             # :nodoc:
-            def validate_action_instance!(json)
-              validate! json, :'action-instance'
-            end
-
-            # :nodoc:
             def validate_entity_collection!(json)
               validate! json, :'entity-collection'
-            end
-
-            # :nodoc:
-            def validate_link_collection!(json)
-              validate! json, :'link-collection'
-            end
-
-            # :nodoc:
-            def validate_resource_collection!(json)
-              validate! json, :'resource-collection'
-            end
-
-            # :nodoc:
-            def validate_mixin_collection!(json)
-              validate! json, :'mixin-collection'
-            end
-
-            # :nodoc:
-            def validate_locations!(json)
-              validate! json, :locations
             end
 
             # :nodoc:

--- a/lib/occi/core/parsers/json/validator/category-identifiers.json
+++ b/lib/occi/core/parsers/json/validator/category-identifiers.json
@@ -1,0 +1,3 @@
+{
+	"$ref": "occi-schema.json#/definitions/category_identifiers"
+}

--- a/lib/occi/core/parsers/json/validator/link-collection.json
+++ b/lib/occi/core/parsers/json/validator/link-collection.json
@@ -1,3 +1,0 @@
-{
-	"$ref": "occi-schema.json#/definitions/link_collection"
-}

--- a/lib/occi/core/parsers/json/validator/mixin-collection.json
+++ b/lib/occi/core/parsers/json/validator/mixin-collection.json
@@ -1,3 +1,0 @@
-{
-	"$ref": "occi-schema.json#/definitions/mixin_collection"
-}

--- a/lib/occi/core/parsers/json/validator/occi-schema.json
+++ b/lib/occi/core/parsers/json/validator/occi-schema.json
@@ -13,52 +13,49 @@
 				"kind": { "type": "string" }
 			}
 		},
-		"resource": {
-			"id": "#resource",
+		"attributes": {
+			"id": "#attributes",
 			"type": "object",
-			"required": ["kind", "id", "attributes"],
+			"additionalProperties": {
+				"oneOf": [
+					{ "type": "number" },
+					{ "type": "boolean" },
+					{ "type": "string" },
+					{ "type": "object" },
+					{ "type": "array" }
+				]
+			}
+		},
+		"attribute_definition": {
+			"id": "#attribute_definition",
+			"type": "object",
 			"additionalProperties": false,
+			"required": ["type", "mutable", "required"],
 			"properties": {
-				"kind": { "type": "string" },
-				"mixins": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
-				"attributes": { "$ref": "#/definitions/attributes" },
-				"actions": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
-				"id": { "type": "string" },
-				"links": {
-					"type": "array",
-					"minItems": 1,
-					"items": {
-						"$ref": "#/definitions/link"
-					}
+				"mutable": { "type": "boolean" },
+				"required": { "type": "boolean" },
+				"type": { "type": "string" },
+				"default": {
+					"oneOf": [
+						{ "type": "number" },
+						{ "type": "string" },
+						{ "type": "boolean" },
+						{ "type": "object" },
+						{ "type": "array" }
+					]
 				},
-				"summary": { "type": "string" },
-				"title": { "type": "string" }
+				"description": { "type": "string" },
+				"pattern": { "type": "string" }
 			}
 		},
-		"action_instance": {
-			"id": "#action_instance",
+		"attribute_definitions": {
+			"id": "#attribute_definitions",
 			"type": "object",
-			"required": ["action"],
 			"additionalProperties": false,
-			"properties": {
-				"action": { "type": "string" },
-				"attributes": { "$ref": "#/definitions/attributes" }
-			}
-		},
-		"link": {
-			"id": "#link",
-			"type": "object",
-			"required": ["kind", "id", "target", "source", "attributes"],
-			"additionalProperties": false,
-			"properties": {
-				"kind": { "type": "string" },
-				"mixins": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
-				"attributes": { "$ref": "#/definitions/attributes" },
-				"actions": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
-				"id": { "type": "string" },
-				"source": { "$ref": "#/definitions/kinded_uri" },
-				"target": { "$ref": "#/definitions/kinded_uri" },
-				"title": { "type": "string" }
+			"patternProperties": {
+				".+": {
+					"$ref": "#/definitions/attribute_definition"
+				}
 			}
 		},
 		"kind": {
@@ -102,6 +99,54 @@
 				"scheme": { "type": "string" },
 				"title": { "type": "string" },
 				"attributes": { "$ref": "#/definitions/attribute_definitions" }
+			}
+		},
+		"action_instance": {
+			"id": "#action_instance",
+			"type": "object",
+			"required": ["action"],
+			"additionalProperties": false,
+			"properties": {
+				"action": { "type": "string" },
+				"attributes": { "$ref": "#/definitions/attributes" }
+			}
+		},
+		"resource": {
+			"id": "#resource",
+			"type": "object",
+			"required": ["kind", "id", "attributes"],
+			"additionalProperties": false,
+			"properties": {
+				"kind": { "type": "string" },
+				"mixins": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
+				"attributes": { "$ref": "#/definitions/attributes" },
+				"actions": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
+				"id": { "type": "string" },
+				"links": {
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/link"
+					}
+				},
+				"summary": { "type": "string" },
+				"title": { "type": "string" }
+			}
+		},
+		"link": {
+			"id": "#link",
+			"type": "object",
+			"required": ["kind", "id", "target", "source", "attributes"],
+			"additionalProperties": false,
+			"properties": {
+				"kind": { "type": "string" },
+				"mixins": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
+				"attributes": { "$ref": "#/definitions/attributes" },
+				"actions": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
+				"id": { "type": "string" },
+				"source": { "$ref": "#/definitions/kinded_uri" },
+				"target": { "$ref": "#/definitions/kinded_uri" },
+				"title": { "type": "string" }
 			}
 		},
 		"resource_collection": {
@@ -155,94 +200,41 @@
 				}
 			}
 		},
-		"kind_collection": {
-			"id": "#kind_collection",
-			"type": "object",
-			"required": ["kinds"],
-			"additionalProperties": false,
-			"properties": {
-				"kinds": {
-					"type": "array",
-					"minItems": 1,
-					"items": {
-						"$ref": "#/definitions/kind"
-					}
-				}
-			}
-		},
-		"mixin_collection": {
-			"id": "#mixin_collection",
+		"mixin_identifiers": {
+			"id": "#mixin_identifiers",
 			"type": "object",
 			"required": ["mixins"],
 			"additionalProperties": false,
 			"properties": {
-				"mixins": {
-					"type": "array",
-					"minItems": 1,
-					"items": {
-						"$ref": "#/definitions/mixin"
-					}
-				}
+				"mixins": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" }
 			}
 		},
-		"action_collection": {
-			"id": "#action_collection",
+		"kind_identifiers": {
+			"id": "#kind_identifiers",
+			"type": "object",
+			"required": ["kinds"],
+			"additionalProperties": false,
+			"properties": {
+				"kinds": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" }
+			}
+		},
+		"action_identifiers": {
+			"id": "#action_identifiers",
 			"type": "object",
 			"required": ["actions"],
 			"additionalProperties": false,
 			"properties": {
-				"actions": {
-					"type": "array",
-					"minItems": 1,
-					"items": {
-						"$ref": "#/definitions/action"
-					}
-				}
+				"actions": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" }
 			}
 		},
-		"attributes": {
-			"id": "#attributes",
-			"type": "object",
-			"additionalProperties": {
-				"oneOf": [
-					{ "type": "number" },
-					{ "type": "boolean" },
-					{ "type": "string" },
-					{ "type": "object" },
-					{ "type": "array" }
-				]
-			}
-		},
-		"attribute_definition": {
-			"id": "#attribute_definition",
+		"category_identifiers": {
+			"id": "#category_identifiers",
 			"type": "object",
 			"additionalProperties": false,
-			"required": ["type", "mutable", "required"],
 			"properties": {
-				"mutable": { "type": "boolean" },
-				"required": { "type": "boolean" },
-				"type": { "type": "string" },
-				"default": {
-					"oneOf": [
-						{ "type": "number" },
-						{ "type": "string" },
-						{ "type": "boolean" },
-						{ "type": "object" },
-						{ "type": "array" }
-					]
-				},
-				"description": { "type": "string" },
-				"pattern": { "type": "string" }
-			}
-		},
-		"attribute_definitions": {
-			"id": "#attribute_definitions",
-			"type": "object",
-			"additionalProperties": false,
-			"patternProperties": {
-				".+": {
-					"$ref": "#/definitions/attribute_definition"
-				}
+				"mixins": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
+				"kinds": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" },
+				"actions": { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" }
 			}
 		},
 		"model": {

--- a/lib/occi/core/parsers/json/validator/resource-collection.json
+++ b/lib/occi/core/parsers/json/validator/resource-collection.json
@@ -1,3 +1,0 @@
-{
-	"$ref": "occi-schema.json#/definitions/resource_collection"
-}

--- a/lib/occi/core/parsers/json_parser.rb
+++ b/lib/occi/core/parsers/json_parser.rb
@@ -67,8 +67,13 @@ module Occi
         # @return [Set] set of instances
         def categories(body, _headers = nil, expectation = nil)
           expectation ||= Occi::Core::Category
-          Json::Validator.validate_model! body
-          Json::Category.json(body, Set.new, false).map { |c| lookup c.identifier, expectation }.to_set
+          Json::Validator.validate_category_identifiers! body
+
+          cats = Set.new
+          hsh = handle(Occi::Core::Errors::ParsingError) { JSON.parse(body) }
+          hsh.values.flatten.each { |cat_id| cats << lookup(cat_id, expectation) }
+
+          cats
         end
 
         # :nodoc:

--- a/lib/occi/core/version.rb
+++ b/lib/occi/core/version.rb
@@ -3,7 +3,7 @@ module Occi
     MAJOR_VERSION = 5                # Major update constant
     MINOR_VERSION = 0                # Minor update constant
     PATCH_VERSION = 0                # Patch/Fix version constant
-    STAGE_VERSION = 'alpha.1'.freeze # use `nil` for production releases
+    STAGE_VERSION = 'alpha.2'.freeze # use `nil` for production releases
 
     unless defined?(::Occi::Core::VERSION)
       VERSION = [


### PR DESCRIPTION
Categories outside of the model are passed only as arrays of identifiers, not full renderings. This has no impact on `text` rendering, however `json` treats this completely differently.