### PR TITLE
Fixed parsing for text attribute values with semicolons

### DIFF
--- a/lib/occi/core/parsers/text/constants.rb
+++ b/lib/occi/core/parsers/text/constants.rb
@@ -4,7 +4,7 @@ module Occi
       module Text
         module Constants
           # Base regular expressions
-          REGEXP_QUOTED_STRING = /([^"\\]|\\.)*/
+          REGEXP_QUOTED_STRING = /([^\\"]|\\\\|\\")*/
           REGEXP_LOALPHA = /[a-z]/
           REGEXP_ALPHA = /[a-zA-Z]/
           REGEXP_DIGIT = /[0-9]/

--- a/lib/occi/core/parsers/text/entity.rb
+++ b/lib/occi/core/parsers/text/entity.rb
@@ -214,9 +214,12 @@ module Occi
             end
             logger.debug "Parsing inline link attributes from line #{md[:attributes].inspect}" if logger_debug?
 
+            regexp = Regexp.new "(\\s*#{Constants::REGEXP_ATTRIBUTE_REPR})"
             line = md[:attributes].strip.gsub(/^;\s*/, '')
-            attrs = line.split(';').map { |attrb| "#{TextParser::ATTRIBUTE_KEYS.first}: #{attrb}" }
-            plain_attributes! attrs, link.attributes
+            plain_attributes!(
+              line.scan(regexp).map { |attrb| "#{TextParser::ATTRIBUTE_KEYS.first}: #{attrb.first}" },
+              link.attributes
+            )
 
             link
           end

--- a/lib/occi/core/parsers/text_parser.rb
+++ b/lib/occi/core/parsers/text_parser.rb
@@ -158,6 +158,7 @@ module Occi
           # @param body [String] multi-line body
           # @return [Array] an array of lines
           def transform_body(body)
+            return [] if body.blank?
             lines = body.respond_to?(:lines) ? body.lines : body.split("\n")
             lines.map(&:strip)
           end
@@ -183,6 +184,8 @@ module Occi
           # @param headers [Hash] hash with raw header key-value pairs
           # @return [Hash] a cleaner hash with relevant headers
           def normalize_headers(headers)
+            return {} unless headers
+
             headers = Hash[
               headers.map { |k, v| [k.gsub(HEADER_HTTP_PREFIX, '').capitalize, v] }
             ]                                                 # remove 'HTTP_' prefix in keys


### PR DESCRIPTION
Inline (link instance) attributes with values containing semicolons are now correctly parsed.