### PR TITLE
Fixed Yell collisions in Rails

### DIFF
--- a/lib/occi/core/helpers/hash_dereferencer.rb
+++ b/lib/occi/core/helpers/hash_dereferencer.rb
@@ -128,7 +128,6 @@ module Occi
         # @param model [Occi::Core::Model] model instance for dereferencing (category look-up)
         # @return [Occi::Core::Category] instance located in the model
         def dereference_via_model(identifier, model)
-          logger.debug "Dereferencing #{identifier.inspect} by look-up in model"
           model.find_by_identifier!(identifier)
         end
 
@@ -139,7 +138,6 @@ module Occi
         # @param hash [Hash] hash with known attribute definitions for dereferencing
         # @return [Occi::Core::AttributeDefinition] definition located in the hash
         def dereference_via_hash(identifier, hash)
-          logger.debug "Dereferencing #{identifier.inspect} by look-up in hash"
           raise "Attribute definition #{identifier.inspect} not found in the hash" unless hash[identifier]
           hash[identifier]
         end

--- a/lib/occi/core/version.rb
+++ b/lib/occi/core/version.rb
@@ -3,7 +3,7 @@ module Occi
     MAJOR_VERSION = 5                # Major update constant
     MINOR_VERSION = 0                # Minor update constant
     PATCH_VERSION = 0                # Patch/Fix version constant
-    STAGE_VERSION = 'beta.1'.freeze # use `nil` for production releases
+    STAGE_VERSION = 'beta.2'.freeze # use `nil` for production releases
 
     unless defined?(::Occi::Core::VERSION)
       VERSION = [

--- a/lib/occi/monkey_island/hash.rb
+++ b/lib/occi/monkey_island/hash.rb
@@ -1,5 +1,4 @@
 # :nodoc:
 class Hash
-  include Yell::Loggable
   include Occi::Core::Helpers::HashDereferencer
 end


### PR DESCRIPTION
`ActiveSupport::OrderedOptions` in Rails extends `Hash` and collides
with `#logger` already added by rOCCI-core's monkey patch. Reverting.