### PR TITLE
Adding `region` mixin to `InfrastructureExt`

### DIFF
--- a/lib/occi/infrastructure_ext/constants.rb
+++ b/lib/occi/infrastructure_ext/constants.rb
@@ -15,6 +15,7 @@ module Occi
 
       # Mixins
       AVAILABILITY_ZONE_MIXIN  = 'http://schemas.ogf.org/occi/infrastructure#availability_zone'.freeze
+      REGION_MIXIN             = 'http://schemas.ogf.org/occi/infrastructure#region'.freeze
     end
   end
 end

--- a/lib/occi/infrastructure_ext/mixins/region.rb
+++ b/lib/occi/infrastructure_ext/mixins/region.rb
@@ -1,0 +1,19 @@
+module Occi
+  module InfrastructureExt
+    module Mixins
+      # A helper class for manipulation with `region` parent mixin. Doesn't
+      # provide any additional functionality aside from the class name.
+      #
+      # @author Boris Parak <parak@cesnet.cz>
+      class Region < Occi::Core::Mixin
+        TITLE = 'OCCI Region mixin'.freeze
+
+        # See `Occi::Core::Mixin` and `Occi::Core::Category`
+        def initialize
+          schema, term = Occi::InfrastructureExt::Constants::REGION_MIXIN.split('#')
+          super term: term, schema: "#{schema}#", title: TITLE
+        end
+      end
+    end
+  end
+end

--- a/lib/occi/infrastructure_ext/model.rb
+++ b/lib/occi/infrastructure_ext/model.rb
@@ -13,6 +13,7 @@ module Occi
         logger.debug 'Loading InfrastructureExt from InfrastructureExt::Warehouse'
         Occi::InfrastructureExt::Warehouse.bootstrap! self
         self << Occi::InfrastructureExt::Mixins::AvailabilityZone.new
+        self << Occi::InfrastructureExt::Mixins::Region.new
         nil
       end
 
@@ -28,6 +29,13 @@ module Occi
       # @return [Set] set of mixins dependent on `availability_zone`
       def find_availability_zones
         find_dependent Occi::InfrastructureExt::Mixins::AvailabilityZone.new
+      end
+
+      # Returns all mixins dependent on the base `region` mixin defined by OGF.
+      #
+      # @return [Set] set of mixins dependent on `region`
+      def find_regions
+        find_dependent Occi::InfrastructureExt::Mixins::Region.new
       end
     end
   end

--- a/spec/occi/infrastructure_ext/mixins/region_spec.rb
+++ b/spec/occi/infrastructure_ext/mixins/region_spec.rb
@@ -1,0 +1,9 @@
+module Occi
+  module InfrastructureExt
+    module Mixins
+      describe Region do
+        it 'does something'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding our second extension mixin (not yet standardized). Mixins dependent on `region` will represent `regions` in AWS EC2 and `zones` in OpenNebula.