### PR TITLE
`Occi::Core::Locations` renders as array only if necessary

### DIFF
--- a/lib/occi/core/renderers/text/locations.rb
+++ b/lib/occi/core/renderers/text/locations.rb
@@ -29,7 +29,15 @@ module Occi
           # @return [Hash] textual representation of Object for headers
           def render_headers
             return {} if object.empty?
-            { LOCATION_KEY_HEADERS => object.map(&:to_s) }
+            { LOCATION_KEY_HEADERS => location_ary_or_first }
+          end
+
+          protected
+
+          # :nodoc:
+          def location_ary_or_first
+            locations = object.map(&:to_s)
+            locations.count == 1 ? locations.first : locations
           end
         end
       end

--- a/lib/occi/core/renderers/text/locations.rb
+++ b/lib/occi/core/renderers/text/locations.rb
@@ -37,7 +37,7 @@ module Occi
           # :nodoc:
           def location_ary_or_first
             locations = object.map(&:to_s)
-            locations.count == 1 ? locations.first : locations
+            locations.many? ? locations : locations.first
           end
         end
       end

--- a/lib/occi/core/version.rb
+++ b/lib/occi/core/version.rb
@@ -3,7 +3,7 @@ module Occi
     MAJOR_VERSION = 5                # Major update constant
     MINOR_VERSION = 0                # Minor update constant
     PATCH_VERSION = 0                # Patch/Fix version constant
-    STAGE_VERSION = 'beta.4'.freeze # use `nil` for production releases
+    STAGE_VERSION = 'beta.5'.freeze # use `nil` for production releases
 
     unless defined?(::Occi::Core::VERSION)
       VERSION = [

--- a/spec/occi/core/renderers/text/locations_spec.rb
+++ b/spec/occi/core/renderers/text/locations_spec.rb
@@ -5,6 +5,9 @@ module Occi
         describe Locations do
           subject(:lsr) { locations_renderer }
 
+          let(:uri) do
+            Set.new([URI.parse('/compute/1')])
+          end
           let(:uris) do
             Set.new(
               [
@@ -15,8 +18,11 @@ module Occi
           end
 
           let(:object) { ::Occi::Core::Locations.new(uris: uris) }
+          let(:object_one) { ::Occi::Core::Locations.new(uris: uri) }
           let(:options) { { format: 'text' } }
+
           let(:locations_renderer) { Locations.new(object, options) }
+          let(:locations_renderer_one) { Locations.new(object_one, options) }
 
           %i[object options].each do |attr|
             it "has #{attr} accessor" do
@@ -38,6 +44,11 @@ module Occi
               it 'renders to headers' do
                 lsr.options = { format: 'headers' }
                 expect(lsr.render).to eq('Location' => ['/compute/1', '/compute/2'])
+              end
+
+              it 'renders one to headers' do
+                locations_renderer_one.options = { format: 'headers' }
+                expect(locations_renderer_one.render).to eq('Location' => '/compute/1')
               end
             end
 


### PR DESCRIPTION
Adjusted `Occi::Core::Locations` rendering to headers. Rendering as array only if necessary.