### PR TITLE
Fixed rendering of Occi::Core::Collection

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,10 @@ task spec: 'rcov:all'
 
 Gem::Tasks.new(build: { tar: true, zip: true }, sign: { checksum: true, pgp: false })
 
-RuboCop::RakeTask.new
+desc 'Execute rubocop -D'
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ['-D'] # display cop name
+end
 
 YARD::Rake::YardocTask.new do |t|
   t.stats_options = ['--list-undoc']

--- a/lib/occi/core/renderers/json/base.rb
+++ b/lib/occi/core/renderers/json/base.rb
@@ -18,8 +18,8 @@ module Occi
           # Shortcuts to interesting object attributes, always prefixed with `object_`
           DELEGATED = %i[
             respond_to? send source target summary kind parent action
-            attributes actions mixins depends applies links rel empty? resources
-            links action_instances
+            attributes actions mixins depends applies rel empty?
+            categories entities resources links action_instances
           ].freeze
           delegate(*DELEGATED, to: :object, prefix: true)
 

--- a/lib/occi/core/renderers/text/base.rb
+++ b/lib/occi/core/renderers/text/base.rb
@@ -18,6 +18,10 @@ module Occi
 
           attr_accessor :object, :options
 
+          # Shortcuts to interesting object attributes, always prefixed with `object_`
+          DELEGATED = %i[send empty? categories entities resources links action_instances].freeze
+          delegate(*DELEGATED, to: :object, prefix: true)
+
           # Constructs a renderer instance for the given
           # object.
           #

--- a/lib/occi/core/renderers/text/collection.rb
+++ b/lib/occi/core/renderers/text/collection.rb
@@ -16,12 +16,11 @@ module Occi
           #
           # @return [String] textual representation of Object
           def render_plain
-            return '' if object.empty?
-            return super if object.only_categories?
+            return '' if object_empty? || object.only_categories?
 
-            if object.only_entities?
+            if ent_no_ai?
               prepare_instances 'entities'
-            elsif object.only_action_instances?
+            elsif ai_no_ent?
               prepare_instances 'action_instances'
             else
               raise Occi::Core::Errors::RenderingError,
@@ -34,12 +33,11 @@ module Occi
           #
           # @return [Hash] textual representation of Object for headers
           def render_headers
-            return {} if object.empty?
-            return super if object.only_categories?
+            return {} if object_empty? || object.only_categories?
 
-            if object.only_entities?
+            if ent_no_ai?
               prepare_instances 'entities'
-            elsif object.only_action_instances?
+            elsif ai_no_ent?
               prepare_instances 'action_instances'
             else
               raise Occi::Core::Errors::RenderingError,
@@ -51,12 +49,22 @@ module Occi
 
           # :nodoc:
           def prepare_instances(type)
-            if object.send(type).count > 1
+            if object_send(type).count > 1
               raise Occi::Core::Errors::RenderingError,
                     "Cannot render collection with multiple #{type.tr('_', ' ')} to text"
             end
 
-            Occi::Core::Renderers::TextRenderer.render object.send(type).first, options
+            Occi::Core::Renderers::TextRenderer.render object_send(type).first, options
+          end
+
+          # :nodoc:
+          def ent_no_ai?
+            object_entities.any? && object_action_instances.empty?
+          end
+
+          # :nodoc:
+          def ai_no_ent?
+            object_action_instances.any? && object_entities.empty?
           end
         end
       end

--- a/lib/occi/core/version.rb
+++ b/lib/occi/core/version.rb
@@ -3,7 +3,7 @@ module Occi
     MAJOR_VERSION = 5                # Major update constant
     MINOR_VERSION = 0                # Minor update constant
     PATCH_VERSION = 0                # Patch/Fix version constant
-    STAGE_VERSION = 'beta.5'.freeze # use `nil` for production releases
+    STAGE_VERSION = 'beta.6'.freeze # use `nil` for production releases
 
     unless defined?(::Occi::Core::VERSION)
       VERSION = [

--- a/spec/occi/core/renderers/text/collection_spec.rb
+++ b/spec/occi/core/renderers/text/collection_spec.rb
@@ -151,12 +151,8 @@ module Occi
                 expect { collection_renderer.render }.not_to raise_error
               end
 
-              it 'renders category lines' do
-                rlines = collection_renderer.render
-                expect(rlines.values.first).to be_kind_of Enumerable
-                expect(rlines.values.first.count).to eq 5
-                expect(rlines.keys.count).to eq 1
-                expect(rlines.keys.first).to eq 'X-OCCI-Category'
+              it 'renders empty' do
+                expect(collection_renderer.render).to be_empty
               end
             end
 
@@ -174,10 +170,7 @@ module Occi
               end
 
               it 'renders category lines' do
-                rlines = collection_renderer.render
-                expect(rlines).to be_kind_of String
-                expect(rlines.lines.count).to eq 5
-                expect(rlines.lines).to all(start_with('Category: '))
+                expect(collection_renderer.render).to be_empty
               end
             end
 
@@ -328,14 +321,14 @@ module Occi
                 expect { collection_renderer.render }.to raise_error(Occi::Core::Errors::RenderingError)
               end
 
-              it 'raises error when combining Category and entity sub-type instance' do
+              it 'does not raise error when combining Category and entity sub-type instance' do
                 collection_renderer.object = c_r_collection
-                expect { collection_renderer.render }.to raise_error(Occi::Core::Errors::RenderingError)
+                expect { collection_renderer.render }.not_to raise_error
               end
 
-              it 'raises error when combining AI and Category' do
+              it 'does not raise error when combining AI and Category' do
                 collection_renderer.object = c_ai_collection
-                expect { collection_renderer.render }.to raise_error(Occi::Core::Errors::RenderingError)
+                expect { collection_renderer.render }.not_to raise_error
               end
             end
 
@@ -356,14 +349,14 @@ module Occi
                 expect { collection_renderer.render }.to raise_error(Occi::Core::Errors::RenderingError)
               end
 
-              it 'raises error when combining Category and entity sub-type instance' do
+              it 'does not raise error when combining Category and entity sub-type instance' do
                 collection_renderer.object = c_r_collection
-                expect { collection_renderer.render }.to raise_error(Occi::Core::Errors::RenderingError)
+                expect { collection_renderer.render }.not_to raise_error
               end
 
-              it 'raises error when combining AI and Category' do
+              it 'does not raise error when combining AI and Category' do
                 collection_renderer.object = c_ai_collection
-                expect { collection_renderer.render }.to raise_error(Occi::Core::Errors::RenderingError)
+                expect { collection_renderer.render }.not_to raise_error
               end
             end
           end


### PR DESCRIPTION
## Overview
When rendering `Occi::Core::Collection`, renderer should not fall back to `Occi::Core::Model` and render only categories. On a similar note, categories should not count as a presence in the collection. Only instances of `Entity` or `ActionInstance`.

## Changes
* Updated renderer for `Occi::Core::Collection`
* Updated renderer specs
* [CI] Changed default `rubocop` configuration
* Version bump (`beta.6`)