### PR TITLE
Support for `default` override on YAML attr_defs

### DIFF
--- a/lib/occi/core/helpers/hash_dereferencer.rb
+++ b/lib/occi/core/helpers/hash_dereferencer.rb
@@ -59,6 +59,8 @@ module Occi
           new_attributes = {}
           self[:attributes].each do |attribute|
             new_attributes[attribute] = dereference_via_hash(attribute, attribute_definitions)
+            next unless fetch(:attribute_defaults, {})[attribute]
+            new_attributes[attribute].default = self[:attribute_defaults][attribute]
           end
           self[:attributes] = new_attributes
 
@@ -132,14 +134,15 @@ module Occi
         end
 
         # Looks up the given attribute definition in the hash. Raises error if no
-        # such attribute definition is found.
+        # such attribute definition is found. The prevent future changes from affecting
+        # new lookups, located definitions are cloned before they are returned.
         #
         # @param identifier [String] attribute identifier (name)
         # @param hash [Hash] hash with known attribute definitions for dereferencing
-        # @return [Occi::Core::AttributeDefinition] definition located in the hash
+        # @return [Occi::Core::AttributeDefinition] definition located in the hash, cloned
         def dereference_via_hash(identifier, hash)
           raise "Attribute definition #{identifier.inspect} not found in the hash" unless hash[identifier]
-          hash[identifier]
+          hash[identifier].clone
         end
 
         private :dereference_via_hash, :dereference_via_model

--- a/lib/occi/core/version.rb
+++ b/lib/occi/core/version.rb
@@ -3,7 +3,7 @@ module Occi
     MAJOR_VERSION = 5                # Major update constant
     MINOR_VERSION = 0                # Minor update constant
     PATCH_VERSION = 0                # Patch/Fix version constant
-    STAGE_VERSION = 'beta.6'.freeze # use `nil` for production releases
+    STAGE_VERSION = 'beta.7'.freeze # use `nil` for production releases
 
     unless defined?(::Occi::Core::VERSION)
       VERSION = [


### PR DESCRIPTION
When reading `Category` definitions from YAML files, using `attribute_defaults` can override `default` values in `AttributeDefinition` read from separate (shared) YAMLs.

```yaml
attributes:
  - occi.compute.cores
  - occi.compute.memory
attribute_defaults:
  occi.compute.cores: 12
  occi.compute.memory: 1.7
```