### PR TITLE
Added INFRA mixins for `ssh_key` and `user_data`

### DIFF
--- a/lib/occi/infrastructure/constants.rb
+++ b/lib/occi/infrastructure/constants.rb
@@ -20,6 +20,8 @@ module Occi
       IPNETWORKINTERFACE_MIXIN = 'http://schemas.ogf.org/occi/infrastructure/networkinterface#ipnetworkinterface'.freeze
       OS_TPL_MIXIN             = 'http://schemas.ogf.org/occi/infrastructure#os_tpl'.freeze
       RESOURCE_TPL_MIXIN       = 'http://schemas.ogf.org/occi/infrastructure#resource_tpl'.freeze
+      USER_DATA_MIXIN          = 'http://schemas.ogf.org/occi/infrastructure/compute#user_data'.freeze
+      SSH_KEY_MIXIN            = 'http://schemas.ogf.org/occi/infrastructure/credentials#ssh_key'.freeze
     end
   end
 end

--- a/lib/occi/infrastructure/warehouse/mixins/attributes/occi.compute.userdata.yml
+++ b/lib/occi/infrastructure/warehouse/mixins/attributes/occi.compute.userdata.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: true
+default: ~
+description: Contextualization data formatted as Base64-encoded string (ref. 'cloud-config')
+pattern: !ruby/regexp '/^.+$/'

--- a/lib/occi/infrastructure/warehouse/mixins/attributes/occi.credentials.ssh.publickey.yml
+++ b/lib/occi/infrastructure/warehouse/mixins/attributes/occi.credentials.ssh.publickey.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: true
+default: ~
+description: Public SSH key formatted as Base64-encoded string (ref. 'authorized_keys')
+pattern: !ruby/regexp '/^.+$/'

--- a/lib/occi/infrastructure/warehouse/mixins/ssh_key.yml
+++ b/lib/occi/infrastructure/warehouse/mixins/ssh_key.yml
@@ -1,0 +1,9 @@
+---
+term: ssh_key
+schema: http://schemas.ogf.org/occi/infrastructure/credentials#
+title: OCCI SSH public key to be injected into a compute instance
+attributes:
+  - occi.credentials.ssh.publickey
+location: /mixin/ssh_key
+applies:
+  - http://schemas.ogf.org/occi/infrastructure#compute

--- a/lib/occi/infrastructure/warehouse/mixins/user_data.yml
+++ b/lib/occi/infrastructure/warehouse/mixins/user_data.yml
@@ -1,0 +1,9 @@
+---
+term: user_data
+schema: http://schemas.ogf.org/occi/infrastructure/compute#
+title: OCCI contextualization data to be injected into a compute instance
+attributes:
+  - occi.compute.userdata
+location: /mixin/user_data
+applies:
+  - http://schemas.ogf.org/occi/infrastructure#compute


### PR DESCRIPTION
Mixins:
* http://schemas.ogf.org/occi/infrastructure/compute#user_data
* http://schemas.ogf.org/occi/infrastructure/credentials#ssh_key

with attributes:
* occi.compute.userdata (`String`, optional)
* occi.credentials.ssh.publickey (`String`, optional)