### PR TITLE
Added helpers for action manipulation on entity

### DIFF
--- a/lib/occi/core/entity.rb
+++ b/lib/occi/core/entity.rb
@@ -222,9 +222,8 @@ module Occi
       #
       # @param action [Occi::Core::Action] action to be added
       def add_action(action)
-        unless action
-          raise Occi::Core::Errors::MandatoryArgumentError,
-                'Cannot add a non-existent action'
+        unless action && kind.actions.include?(action)
+          raise Occi::Core::Errors::MandatoryArgumentError, 'Cannot add an action that is empty or not defined on kind'
         end
         actions << action
       end
@@ -234,10 +233,33 @@ module Occi
       # @param action [Occi::Core::Action] action to be removed
       def remove_action(action)
         unless action
-          raise Occi::Core::Errors::MandatoryArgumentError,
-                'Cannot remove a non-existent action'
+          raise Occi::Core::Errors::MandatoryArgumentError, 'Cannot remove a non-existent action'
         end
         actions.delete action
+      end
+
+      # Enables action identified by `term` on this instance. Actions are looked up
+      # in `kind.actions`. Unknown actions will raise errors.
+      #
+      # @example
+      #    entity.enable_action 'start'
+      #
+      # @param term [String] action term
+      def enable_action(term)
+        add_action(kind.actions.detect { |a| a.term == term })
+      end
+
+      # Disables action identified by `term` on this instance. Unknown actions
+      # will NOT raise errors.
+      #
+      # @example
+      #    entity.disable_action 'start'
+      #
+      # @param term [String] action term
+      def disable_action(term)
+        action = actions.detect { |a| a.term == term }
+        return unless action
+        remove_action action
       end
 
       # Validates the content of this entity instance, including

--- a/spec/occi/core/entity_spec.rb
+++ b/spec/occi/core/entity_spec.rb
@@ -26,7 +26,8 @@ module Occi
           term: 'root',
           schema: 'http://test.org/root#',
           title: 'Root kind',
-          attributes: attributes
+          attributes: attributes,
+          actions: actions.clone
         )
       end
 
@@ -176,7 +177,8 @@ module Occi
 
         context 'with action' do
           before do
-            ent.actions = actions
+            ent.actions = actions.clone
+            kind.actions << action << action2
           end
 
           context 'assigned to entity' do
@@ -424,6 +426,46 @@ module Occi
         context 'when no action is provided' do
           it 'fails' do
             expect { ent.remove_action(nil) }.to raise_error(Occi::Core::Errors::MandatoryArgumentError)
+          end
+        end
+      end
+
+      describe '#enable_action' do
+        before do
+          ent.actions = Set.new
+          allow(action).to receive(:term).and_return('start')
+        end
+
+        context 'when action exists' do
+          it 'adds action from kind to entity' do
+            expect { ent.enable_action('start') }.not_to raise_error
+            expect(ent.actions).to include(action)
+          end
+        end
+
+        context 'when action does not exist' do
+          it 'raises error' do
+            expect { ent.enable_action 'meh' }.to raise_error(Occi::Core::Errors::MandatoryArgumentError)
+          end
+        end
+      end
+
+      describe '#disable_action' do
+        before do
+          ent.actions = Set.new([action])
+          allow(action).to receive(:term).and_return('start')
+        end
+
+        context 'when action exists' do
+          it 'removes action from entity' do
+            expect { ent.disable_action('start') }.not_to raise_error
+            expect(ent.actions).not_to include(action)
+          end
+        end
+
+        context 'when action does not exist' do
+          it 'finishes quietly' do
+            expect { ent.disable_action 'meh' }.not_to raise_error
           end
         end
       end


### PR DESCRIPTION
`enable_action` and `disable_action` on `Occi::Core::Entity` allow manipulation of actions by `term`. Actions handled by these methods must be defined on `kind` associated with the instance.

Example:
```ruby
entity.actions.empty? # => true
entity.enable_action 'start'
entity.actions.empty? # => false

entity.disable_action 'start'
entity.actions.empty? # => true

entity.enable_action 'meh' # => error, not defined on `kind`
```