### PR TITLE
Correctly adding links to instances from JSON and TEXT

### DIFF
--- a/lib/occi/core/parsers/json/action_instance.rb
+++ b/lib/occi/core/parsers/json/action_instance.rb
@@ -29,7 +29,7 @@ module Occi
               logger.debug "Identified #{action.class}[#{action.identifier}]"
               ai = Occi::Core::ActionInstance.new(action: action)
               ep = Entity.new(model: model)
-              ep.set_attributes!(ai.attributes, parsed[:attributes]) if parsed[:attributes]
+              ep.set_attributes!(ai, parsed[:attributes]) if parsed[:attributes]
 
               logger.debug "Parsed into ActionInstance #{ai.inspect}" if logger_debug?
               ai

--- a/lib/occi/core/parsers/text/entity.rb
+++ b/lib/occi/core/parsers/text/entity.rb
@@ -175,7 +175,7 @@ module Occi
 
             link = plain_oglink_instance(md)
             link.location = handle(Occi::Core::Errors::ParsingError) { URI.parse md[:self] }
-            entity.links << link
+            entity.add_link link
 
             plain_oglink_attributes! md, link
 


### PR DESCRIPTION
Links must be always added via `#<<` or `#add_link` on `Occi::Core::Resource`. Adding them directly will leave `source` and `source_kind` unset or outdated.