### PR TITLE
Amending attribute definitions in Warehouse(s)

### DIFF
--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.compute.state.message.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.compute.state.message.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: false
+default: ~
+description: Human-readable description of the current state.
+pattern: ~

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.network.state.message.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.network.state.message.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: false
+default: ~
+description: Human-readable description of the current state.
+pattern: ~

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.networkinterface.state.message.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.networkinterface.state.message.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: false
+default: ~
+description: Human-readable description of the current state.
+pattern: ~

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storage.size.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storage.size.yml
@@ -1,5 +1,5 @@
 ---
-type: !ruby/class Integer
+type: !ruby/class Float
 required: false
 mutable: true
 default: ~

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storage.state.message.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storage.state.message.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: false
+default: ~
+description: Human-readable description of the current state.
+pattern: ~

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storagelink.state.message.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storagelink.state.message.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: false
+default: ~
+description: Human-readable description of the current state.
+pattern: ~

--- a/lib/occi/infrastructure/warehouse/kinds/compute.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/compute.yml
@@ -11,6 +11,7 @@ attributes:
   - occi.compute.memory
   - occi.compute.speed
   - occi.compute.state
+  - occi.compute.state.message
 actions:
   - http://schemas.ogf.org/occi/infrastructure/compute/action#start
   - http://schemas.ogf.org/occi/infrastructure/compute/action#stop

--- a/lib/occi/infrastructure/warehouse/kinds/network.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/network.yml
@@ -8,6 +8,7 @@ attributes:
   - occi.network.vlan
   - occi.network.label
   - occi.network.state
+  - occi.network.state.message
 actions:
   - http://schemas.ogf.org/occi/infrastructure/network/action#up
   - http://schemas.ogf.org/occi/infrastructure/network/action#down

--- a/lib/occi/infrastructure/warehouse/kinds/networkinterface.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/networkinterface.yml
@@ -8,6 +8,7 @@ attributes:
   - occi.networkinterface.interface
   - occi.networkinterface.mac
   - occi.networkinterface.state
+  - occi.networkinterface.state.message
 actions:
   - http://schemas.ogf.org/occi/infrastructure/networkinterface/action#up
   - http://schemas.ogf.org/occi/infrastructure/networkinterface/action#down

--- a/lib/occi/infrastructure/warehouse/kinds/storage.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/storage.yml
@@ -7,6 +7,7 @@ location: /storage/
 attributes:
   - occi.storage.size
   - occi.storage.state
+  - occi.storage.state.message
 actions:
   - http://schemas.ogf.org/occi/infrastructure/storage/action#online
   - http://schemas.ogf.org/occi/infrastructure/storage/action#offline

--- a/lib/occi/infrastructure/warehouse/kinds/storagelink.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/storagelink.yml
@@ -8,6 +8,7 @@ attributes:
   - occi.storagelink.deviceid
   - occi.storagelink.mountpoint
   - occi.storagelink.state
+  - occi.storagelink.state.message
 actions:
   - http://schemas.ogf.org/occi/infrastructure/storagelink/action#online
   - http://schemas.ogf.org/occi/infrastructure/storagelink/action#offline

--- a/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.ipreservation.state.message.yml
+++ b/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.ipreservation.state.message.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: false
+default: ~
+description: Human-readable description of the current state.
+pattern: ~

--- a/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.securitygroup.state.message.yml
+++ b/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.securitygroup.state.message.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: false
+default: ~
+description: Human-readable description of the current state.
+pattern: ~

--- a/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.securitygrouplink.state.message.yml
+++ b/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.securitygrouplink.state.message.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: false
+default: ~
+description: Human-readable description of the current state.
+pattern: ~

--- a/lib/occi/infrastructure_ext/warehouse/kinds/ipreservation.yml
+++ b/lib/occi/infrastructure_ext/warehouse/kinds/ipreservation.yml
@@ -8,6 +8,7 @@ attributes:
   - occi.ipreservation.address
   - occi.ipreservation.used
   - occi.ipreservation.state
+  - occi.ipreservation.state.message
 actions:
   - http://schemas.ogf.org/occi/infrastructure/ipreservation/action#up
   - http://schemas.ogf.org/occi/infrastructure/ipreservation/action#down

--- a/lib/occi/infrastructure_ext/warehouse/kinds/securitygroup.yml
+++ b/lib/occi/infrastructure_ext/warehouse/kinds/securitygroup.yml
@@ -7,3 +7,4 @@ location: /securitygroup/
 attributes:
   - occi.securitygroup.rules
   - occi.securitygroup.state
+  - occi.securitygroup.state.message

--- a/lib/occi/infrastructure_ext/warehouse/kinds/securitygrouplink.yml
+++ b/lib/occi/infrastructure_ext/warehouse/kinds/securitygrouplink.yml
@@ -6,3 +6,4 @@ parent: http://schemas.ogf.org/occi/core#link
 location: /link/securitygrouplink/
 attributes:
   - occi.securitygrouplink.state
+  - occi.securitygrouplink.state.message


### PR DESCRIPTION
## Changes
* Changed attribute type for `occi.storage.size` from `Integer` to `Float`
* Added attributes for `*.state.message` to every `Occi::Core::Entity` subtype