### PR TITLE
Adding support for `floatingippool` support

### DIFF
--- a/lib/occi/infrastructure_ext/constants.rb
+++ b/lib/occi/infrastructure_ext/constants.rb
@@ -16,6 +16,7 @@ module Occi
       # Mixins
       AVAILABILITY_ZONE_MIXIN  = 'http://schemas.ogf.org/occi/infrastructure#availability_zone'.freeze
       REGION_MIXIN             = 'http://schemas.ogf.org/occi/infrastructure#region'.freeze
+      FLOATINGIPPOOL_MIXIN     = 'http://schemas.openstack.org/network#floatingippool'.freeze
     end
   end
 end

--- a/lib/occi/infrastructure_ext/mixins/floatingippool.rb
+++ b/lib/occi/infrastructure_ext/mixins/floatingippool.rb
@@ -1,0 +1,19 @@
+module Occi
+  module InfrastructureExt
+    module Mixins
+      # A helper class for manipulation with `floatingippool` parent mixin. Doesn't
+      # provide any additional functionality aside from the class name.
+      #
+      # @author Boris Parak <parak@cesnet.cz>
+      class Floatingippool < Occi::Core::Mixin
+        TITLE = 'OCCI Floatingippool mixin'.freeze
+
+        # See `Occi::Core::Mixin` and `Occi::Core::Category`
+        def initialize
+          schema, term = Occi::InfrastructureExt::Constants::FLOATINGIPPOOL_MIXIN.split('#')
+          super term: term, schema: "#{schema}#", title: TITLE
+        end
+      end
+    end
+  end
+end

--- a/lib/occi/infrastructure_ext/model.rb
+++ b/lib/occi/infrastructure_ext/model.rb
@@ -14,6 +14,7 @@ module Occi
         Occi::InfrastructureExt::Warehouse.bootstrap! self
         self << Occi::InfrastructureExt::Mixins::AvailabilityZone.new
         self << Occi::InfrastructureExt::Mixins::Region.new
+        self << Occi::InfrastructureExt::Mixins::Floatingippool.new
         nil
       end
 
@@ -36,6 +37,13 @@ module Occi
       # @return [Set] set of mixins dependent on `region`
       def find_regions
         find_dependent Occi::InfrastructureExt::Mixins::Region.new
+      end
+
+      # Returns all mixins dependent on the base `floatingippool` mixin defined by OGF.
+      #
+      # @return [Set] set of mixins dependent on `floatingippool`
+      def find_floatingippools
+        find_dependent Occi::InfrastructureExt::Mixins::Floatingippool.new
       end
     end
   end


### PR DESCRIPTION
`http://schemas.openstack.org/network#floatingippool` for creating IPReservations.