### PR TITLE
Rendering JSON-like values to TEXT with escaping

### DIFF
--- a/lib/occi/core/parsers/text/entity.rb
+++ b/lib/occi/core/parsers/text/entity.rb
@@ -25,7 +25,7 @@ module Occi
           DEFAULT_LAMBDA  = ->(val) { raise "#{self} -> Cannot typecast #{val.inspect} to an unknown type" }
 
           FLOAT_LAMBDA    = ->(val) { val.to_f }
-          JSON_LAMBDA     = ->(val) { JSON.parse(val) }
+          JSON_LAMBDA     = ->(val) { JSON.parse(val.gsub('\"', '"')) }
 
           TYPECASTER_HASH = {
             IPAddr  => ->(val) { IPAddr.new val },

--- a/lib/occi/core/renderers/text/attributes.rb
+++ b/lib/occi/core/renderers/text/attributes.rb
@@ -72,7 +72,7 @@ module Occi
             if (QUOTABLE_TYPES & type_ancestors).any?
               "\"#{value}\""
             elsif (JSONABLE_TYPES & type_ancestors).any?
-              "\"#{value.to_json}\""
+              value.to_json.inspect
             elsif (PRIMITIVE_TYPES & type_ancestors).any?
               value.inspect
             else


### PR DESCRIPTION
This ensures at least partial support for complex attributes in TEXT rendering. JSON-like attributes are rendered as JSON strings and first-level double-quotes (`"`) are escaped to `\"`. This is not fool-proof and will fail for various nested strings etc.