### PR TITLE
Added mixins to help with network lookup

### DIFF
--- a/lib/occi/infrastructure_ext/constants.rb
+++ b/lib/occi/infrastructure_ext/constants.rb
@@ -14,9 +14,13 @@ module Occi
       SECURITY_GROUP_LINK_KIND = 'http://schemas.ogf.org/occi/infrastructure#securitygrouplink'.freeze
 
       # Mixins
-      AVAILABILITY_ZONE_MIXIN  = 'http://schemas.ogf.org/occi/infrastructure#availability_zone'.freeze
-      REGION_MIXIN             = 'http://schemas.ogf.org/occi/infrastructure#region'.freeze
-      FLOATINGIPPOOL_MIXIN     = 'http://schemas.openstack.org/network#floatingippool'.freeze
+      AVAILABILITY_ZONE_MIXIN = 'http://schemas.ogf.org/occi/infrastructure#availability_zone'.freeze
+      REGION_MIXIN            = 'http://schemas.ogf.org/occi/infrastructure#region'.freeze
+      FLOATINGIPPOOL_MIXIN    = 'http://schemas.openstack.org/network#floatingippool'.freeze
+      PUBLIC_NET_MIXIN        = 'http://schemas.fedcloud.egi.eu/occi/infrastructure/network#public_net'.freeze
+      PRIVATE_NET_MIXIN       = 'http://schemas.fedcloud.egi.eu/occi/infrastructure/network#private_net'.freeze
+      NAT_NET_MIXIN           = 'http://schemas.fedcloud.egi.eu/occi/infrastructure/network#nat_net'.freeze
+      DEFAULT_CONNECT_MIXIN   = 'http://schemas.fedcloud.egi.eu/occi/infrastructure/compute#default_connectivity'.freeze
     end
   end
 end

--- a/lib/occi/infrastructure_ext/warehouse/mixins/attributes/eu.egi.fedcloud.compute.default_connectivity.yml
+++ b/lib/occi/infrastructure_ext/warehouse/mixins/attributes/eu.egi.fedcloud.compute.default_connectivity.yml
@@ -1,0 +1,7 @@
+---
+type: !ruby/class String
+required: false
+mutable: false
+default: ~
+description: Default connectivity for new compute instances.
+pattern: !ruby/regexp '/^(public|private|nat)$/'

--- a/lib/occi/infrastructure_ext/warehouse/mixins/default_connectivity.yml
+++ b/lib/occi/infrastructure_ext/warehouse/mixins/default_connectivity.yml
@@ -1,0 +1,9 @@
+---
+term: default_connectivity
+schema: http://schemas.fedcloud.egi.eu/occi/infrastructure/compute#
+title: OCCI Default Connectivity mixin
+attributes:
+  - eu.egi.fedcloud.compute.default_connectivity
+location: /mixin/default_connectivity/
+applies:
+  - http://schemas.ogf.org/occi/infrastructure#compute

--- a/lib/occi/infrastructure_ext/warehouse/mixins/nat_net.yml
+++ b/lib/occi/infrastructure_ext/warehouse/mixins/nat_net.yml
@@ -1,0 +1,7 @@
+---
+term: nat_net
+schema: http://schemas.fedcloud.egi.eu/occi/infrastructure/network#
+title: OCCI NAT Network mixin
+location: /mixin/nat_net/
+applies:
+  - http://schemas.ogf.org/occi/infrastructure#network

--- a/lib/occi/infrastructure_ext/warehouse/mixins/private_net.yml
+++ b/lib/occi/infrastructure_ext/warehouse/mixins/private_net.yml
@@ -1,0 +1,7 @@
+---
+term: private_net
+schema: http://schemas.fedcloud.egi.eu/occi/infrastructure/network#
+title: OCCI Private Network mixin
+location: /mixin/private_net/
+applies:
+  - http://schemas.ogf.org/occi/infrastructure#network

--- a/lib/occi/infrastructure_ext/warehouse/mixins/public_net.yml
+++ b/lib/occi/infrastructure_ext/warehouse/mixins/public_net.yml
@@ -1,0 +1,7 @@
+---
+term: public_net
+schema: http://schemas.fedcloud.egi.eu/occi/infrastructure/network#
+title: OCCI Public Network mixin
+location: /mixin/public_net/
+applies:
+  - http://schemas.ogf.org/occi/infrastructure#network


### PR DESCRIPTION
## Added Mixins
* `public_net`  - for publicly routed networks
* `private_net` - for local networks
* `nat_net`     - for networks with outgoing connectivity
* `default_connectivity` - indicating type assigned by default, one of `public, private, nat`

## Usage
The first three should be added to network instances. The last one should be present in the model with the correct default value for the `eu.egi.fedcloud.compute.default_connectivity` attribute (not necessary to assign).