### PR TITLE
Adding mixin selection helpers to entity

### DIFF
--- a/lib/occi/core/entity.rb
+++ b/lib/occi/core/entity.rb
@@ -22,13 +22,13 @@ module Occi
       include Helpers::InstanceAttributesAccessor
       include Helpers::ArgumentValidator
       include Helpers::InstanceAttributeResetter
+      include Helpers::MixinSelector
 
       attr_accessor :kind, :actions, :attributes, :mixins
       attr_writer :location
 
       ERRORS = [
-        Occi::Core::Errors::AttributeValidationError,
-        Occi::Core::Errors::AttributeDefinitionError,
+        Occi::Core::Errors::AttributeValidationError, Occi::Core::Errors::AttributeDefinitionError,
         Occi::Core::Errors::InstanceValidationError
       ].freeze
 

--- a/lib/occi/core/errors/instance_lookup_error.rb
+++ b/lib/occi/core/errors/instance_lookup_error.rb
@@ -1,0 +1,11 @@
+module Occi
+  module Core
+    module Errors
+      # Custom error class indicating look-up failures on
+      # instances.
+      #
+      # @author Boris Parak <parak@cesnet.cz>
+      class InstanceLookupError < StandardError; end
+    end
+  end
+end

--- a/lib/occi/core/helpers/mixin_selector.rb
+++ b/lib/occi/core/helpers/mixin_selector.rb
@@ -1,0 +1,40 @@
+module Occi
+  module Core
+    module Helpers
+      # Introduces mixin-based helpers to every receiver
+      # class. Provides methods to access mixin sub-sets
+      # defined by dependencies.
+      #
+      # @author Boris Parak <parak@cesnet.cz>
+      module MixinSelector
+        # Selects a set of mixins defined by a common dependence. This dependence
+        # must be provided as `filter` and be an instance of `Occi::Core::Mixin` or
+        # its subclass.
+        #
+        # @param filter [Occi::Core::Mixin] mixin to filter by
+        # @return [Set] found mixins
+        def select_mixins(filter)
+          Set.new(mixins.select { |m| m.depends?(filter) })
+        end
+
+        # Selects at most one mixin defined by the given dependence. This dependence
+        # must be provided as `filter` and be an instance of `Occi::Core::Mixin` or
+        # its subclass.
+        #
+        # @param filter [Occi::Core::Mixin] mixin to filter by
+        # @return [Occi::Core::Mixin] found mixin
+        # @return [NilClass] if such mixin is not found
+        def select_mixin(filter)
+          mixins.detect { |m| m.depends?(filter) }
+        end
+
+        # Selects exactly one mixin or raises an error.
+        # @see `select_mixin`
+        def select_mixin!(filter)
+          select_mixin(filter) \
+            || raise(Occi::Core::Errors::InstanceLookupError, "Mixin dependent on #{filter} not found")
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/renderers.rb
+++ b/spec/helpers/renderers.rb
@@ -1,5 +1,7 @@
 module RocciCoreSpec
   class TestObject
+    def mixins; end
+
     def to_the_dummiest_dummy
       'original method'
     end

--- a/spec/occi/core/helpers/mixin_selector_spec.rb
+++ b/spec/occi/core/helpers/mixin_selector_spec.rb
@@ -1,0 +1,100 @@
+module Occi
+  module Core
+    module Helpers
+      describe MixinSelector do
+        let(:selectable_object) do
+          object = instance_double('RocciCoreSpec::TestObject')
+          object.extend(MixinSelector)
+          object
+        end
+
+        let(:mxn1) { instance_double('Occi::Core::Mixin') }
+        let(:mxn2) { instance_double('Occi::Core::Mixin') }
+        let(:mixins_full) { Set.new([mxn1, mxn2]) }
+
+        describe '#select_mixins' do
+          before do
+            allow(selectable_object).to receive(:mixins).and_return(mixins_full)
+            allow(mxn1).to receive(:depends?).with(mxn1).and_return(false)
+          end
+
+          context 'without deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(false)
+            end
+
+            it 'returns empty enumerable' do
+              expect(selectable_object.select_mixins(mxn1)).to be_kind_of(Enumerable)
+              expect(selectable_object.select_mixins(mxn1)).to be_empty
+            end
+          end
+
+          context 'with deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(true)
+            end
+
+            it 'returns dependent mixins' do
+              expect(selectable_object.select_mixins(mxn1)).to be_kind_of(Enumerable)
+              expect(selectable_object.select_mixins(mxn1)).to include(mxn2)
+            end
+          end
+        end
+
+        describe '#select_mixin' do
+          before do
+            allow(selectable_object).to receive(:mixins).and_return(mixins_full)
+            allow(mxn1).to receive(:depends?).with(mxn1).and_return(false)
+          end
+
+          context 'without deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(false)
+            end
+
+            it 'returns nil' do
+              expect(selectable_object.select_mixin(mxn1)).to be_nil
+            end
+          end
+
+          context 'with deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(true)
+            end
+
+            it 'returns dependent mixin' do
+              expect(selectable_object.select_mixin(mxn1)).to be mxn2
+            end
+          end
+        end
+
+        describe '#select_mixin!' do
+          before do
+            allow(selectable_object).to receive(:mixins).and_return(mixins_full)
+            allow(mxn1).to receive(:depends?).with(mxn1).and_return(false)
+          end
+
+          context 'without deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(false)
+            end
+
+            it 'raises error' do
+              expect { selectable_object.select_mixin!(mxn1) }.to raise_error(Occi::Core::Errors::InstanceLookupError)
+            end
+          end
+
+          context 'with deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(true)
+            end
+
+            it 'returns dependent mixin' do
+              expect(selectable_object.select_mixin!(mxn1)).to be mxn2
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Helps with selecting mixins on `Occi::Core::Entity` instances. For example, if you are looking for all mixins dependent on `availability_zone` assigned to an entity (sub-type) instance:
```ruby
az = model.find_by_identifier!(Occi::InfrastructureExt::Constants::AVAILABILITY_ZONE_MIXIN)
entity.select_mixins(az) # => #<Set ...>
```