### PR TITLE
Fixed rendering of IPAddr

### DIFF
--- a/lib/occi/core.rb
+++ b/lib/occi/core.rb
@@ -62,6 +62,7 @@ end
 # Explicitly load monkey patches
 require 'occi/monkey_island/boolean'
 require 'occi/monkey_island/hash'
+require 'occi/monkey_island/ipaddr'
 
 # Explicitly pull in versioning information
 require 'occi/core/version'

--- a/lib/occi/core/renderers/json/attributes.rb
+++ b/lib/occi/core/renderers/json/attributes.rb
@@ -11,10 +11,9 @@ module Occi
         class Attributes < Base
           # Typecasting lambdas
           DEFAULT_LAMBDA  = ->(val) { val }
-          STRING_LAMBDA   = ->(val) { val.to_s }
           TYPECASTER_HASH = {
-            IPAddr => STRING_LAMBDA,
-            URI    => STRING_LAMBDA
+            IPAddr => ->(val) { val.host? ? val.to_s : "#{val}/#{val.cidr_mask}" },
+            URI    => ->(val) { val.to_s }
           }.freeze
 
           # Renders the given object to `JSON`.

--- a/lib/occi/monkey_island/ipaddr.rb
+++ b/lib/occi/monkey_island/ipaddr.rb
@@ -1,0 +1,38 @@
+# :nodoc:
+class IPAddr
+  AF_INET_FULL_MASK = 32
+  AF_INET6_FULL_MASK = 128
+
+  attr_reader :mask_addr
+
+  # Converts network mask to CIDR format.
+  #
+  # @return [Integer] CIDR representation of address mask
+  def cidr_mask
+    case family
+    when Socket::AF_INET
+      AF_INET_FULL_MASK - Math.log2((1 << AF_INET_FULL_MASK) - mask_addr).to_i
+    when Socket::AF_INET6
+      AF_INET6_FULL_MASK - Math.log2((1 << AF_INET6_FULL_MASK) - mask_addr).to_i
+    else
+      raise AddressFamilyError, 'unsupported address family'
+    end
+  end
+
+  # :nodoc:
+  def host?
+    case family
+    when Socket::AF_INET
+      cidr_mask == AF_INET_FULL_MASK
+    when Socket::AF_INET6
+      cidr_mask == AF_INET6_FULL_MASK
+    else
+      raise AddressFamilyError, 'unsupported address family'
+    end
+  end
+
+  # :nodoc:
+  def network?
+    !host?
+  end
+end


### PR DESCRIPTION
Rendering of IPAddr to TEXT and JSON requires different handling of masks. Host addresses are rendered in a standard way (via `to_s`) and network addresses must include network mask in CIDR notation.