### PR TITLE
Additional mixin and links selectors

### DIFF
--- a/lib/occi/core/entity.rb
+++ b/lib/occi/core/entity.rb
@@ -295,7 +295,7 @@ module Occi
       #
       # @return [NilClass] when entity instance is valid
       def valid!
-        %i[kind id location title attributes mixins actions].each do |attr|
+        %i[kind location attributes mixins actions].each do |attr|
           unless send(attr)
             raise Occi::Core::Errors::InstanceValidationError,
                   "Missing valid #{attr}"

--- a/lib/occi/core/helpers/mixin_selector.rb
+++ b/lib/occi/core/helpers/mixin_selector.rb
@@ -34,6 +34,24 @@ module Occi
           select_mixin(filter) \
             || raise(Occi::Core::Errors::InstanceLookupError, "Mixin dependent on #{filter} not found")
         end
+
+        # Returns a list of term of mixins dependent on the given mixin.
+        #
+        # @param mixin [Occi::Core::Mixin] parent mixin
+        # @return [Array] terms of mixins
+        def dependent_terms(mixin)
+          select_mixins(mixin).map(&:term)
+        end
+
+        # @see `dependent_terms`
+        def dependent_term(mixin)
+          [select_mixin(mixin)].compact.map(&:term).first
+        end
+
+        # @see `dependent_term`
+        def dependent_term!(mixin)
+          select_mixin!(mixin).term
+        end
       end
     end
   end

--- a/lib/occi/core/resource.rb
+++ b/lib/occi/core/resource.rb
@@ -21,14 +21,12 @@ module Occi
       end
 
       # @param links [Set] set of links
-      def links=(links)
-        unless links
-          raise Occi::Core::Errors::InstanceValidationError,
-                'Missing valid links'
-        end
+      def links=(new_links)
+        raise Occi::Core::Errors::InstanceValidationError, 'Missing valid links' unless new_links
+
         @links ||= Set.new
         @links.each { |l| remove_link(l) }
-        links.each { |l| add_link(l) }
+        new_links.each { |l| add_link(l) }
 
         @links
       end
@@ -59,10 +57,8 @@ module Occi
       #
       # @param link [Occi::Core::Link] link to be added
       def add_link(link)
-        unless link
-          raise Occi::Core::Errors::MandatoryArgumentError,
-                'Cannot add a non-existent link'
-        end
+        raise Occi::Core::Errors::MandatoryArgumentError, 'Cannot add a non-existent link' unless link
+
         link.source = location
         link.source_kind = kind
         links << link
@@ -72,10 +68,8 @@ module Occi
       #
       # @param link [Occi::Core::Link] link to be removed
       def remove_link(link)
-        unless link
-          raise Occi::Core::Errors::MandatoryArgumentError,
-                'Cannot remove a non-existent link'
-        end
+        raise Occi::Core::Errors::MandatoryArgumentError, 'Cannot remove a non-existent link' unless link
+
         link.source = nil
         link.source_kind = nil
         links.delete link
@@ -83,12 +77,25 @@ module Occi
 
       # See `#valid!` on `Occi::Core::Entity`.
       def valid!
-        unless links
-          raise Occi::Core::Errors::InstanceValidationError,
-                'Missing valid links'
-        end
-        links.each(&:valid!)
         super
+
+        raise Occi::Core::Errors::InstanceValidationError, 'Missing valid links' unless links
+        links.each(&:valid!)
+      end
+
+      # :nodoc:
+      def links_by_klass(klass)
+        links.select { |l| l.is_a?(klass) }
+      end
+
+      # :nodoc:
+      def links_by_kind(kind)
+        links.select { |l| l.kind == kind }
+      end
+
+      # :nodoc:
+      def links_by_kind_identifier(kind_identifier)
+        links.select { |l| l.kind_identifier == kind_identifier }
       end
 
       protected
@@ -103,8 +110,7 @@ module Occi
         super
 
         return unless args[:links].nil?
-        raise Occi::Core::Errors::MandatoryArgumentError,
-              "Links is a mandatory argument for #{self.class}"
+        raise Occi::Core::Errors::MandatoryArgumentError, "Links is a mandatory argument for #{self.class}"
       end
 
       # :nodoc:

--- a/spec/occi/core/entity_spec.rb
+++ b/spec/occi/core/entity_spec.rb
@@ -491,7 +491,7 @@ module Occi
           before { ent.id = nil }
 
           it 'raises error' do
-            expect { ent.valid! }.to raise_error(Occi::Core::Errors::InstanceValidationError)
+            expect { ent.valid! }.to raise_error(Occi::Core::Errors::MandatoryArgumentError)
           end
         end
 

--- a/spec/occi/core/helpers/mixin_selector_spec.rb
+++ b/spec/occi/core/helpers/mixin_selector_spec.rb
@@ -41,6 +41,36 @@ module Occi
           end
         end
 
+        describe '#dependent_terms' do
+          before do
+            allow(selectable_object).to receive(:mixins).and_return(mixins_full)
+            allow(mxn1).to receive(:depends?).with(mxn1).and_return(false)
+          end
+
+          context 'without deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(false)
+            end
+
+            it 'returns empty enumerable' do
+              expect(selectable_object.dependent_terms(mxn1)).to be_kind_of(Enumerable)
+              expect(selectable_object.dependent_terms(mxn1)).to be_empty
+            end
+          end
+
+          context 'with deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(true)
+              allow(mxn2).to receive(:term).and_return('mxn2_term')
+            end
+
+            it 'returns dependent mixins' do
+              expect(selectable_object.dependent_terms(mxn1)).to be_kind_of(Enumerable)
+              expect(selectable_object.dependent_terms(mxn1)).to include('mxn2_term')
+            end
+          end
+        end
+
         describe '#select_mixin' do
           before do
             allow(selectable_object).to receive(:mixins).and_return(mixins_full)
@@ -68,6 +98,34 @@ module Occi
           end
         end
 
+        describe '#dependent_term' do
+          before do
+            allow(selectable_object).to receive(:mixins).and_return(mixins_full)
+            allow(mxn1).to receive(:depends?).with(mxn1).and_return(false)
+          end
+
+          context 'without deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(false)
+            end
+
+            it 'returns nil' do
+              expect(selectable_object.dependent_term(mxn1)).to be_nil
+            end
+          end
+
+          context 'with deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(true)
+              allow(mxn2).to receive(:term).and_return('mxn2_term')
+            end
+
+            it 'returns dependent mixin' do
+              expect(selectable_object.dependent_term(mxn1)).to eq 'mxn2_term'
+            end
+          end
+        end
+
         describe '#select_mixin!' do
           before do
             allow(selectable_object).to receive(:mixins).and_return(mixins_full)
@@ -91,6 +149,34 @@ module Occi
 
             it 'returns dependent mixin' do
               expect(selectable_object.select_mixin!(mxn1)).to be mxn2
+            end
+          end
+        end
+
+        describe '#dependent_term!' do
+          before do
+            allow(selectable_object).to receive(:mixins).and_return(mixins_full)
+            allow(mxn1).to receive(:depends?).with(mxn1).and_return(false)
+          end
+
+          context 'without deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(false)
+            end
+
+            it 'raises error' do
+              expect { selectable_object.dependent_term!(mxn1) }.to raise_error(Occi::Core::Errors::InstanceLookupError)
+            end
+          end
+
+          context 'with deps' do
+            before do
+              allow(mxn2).to receive(:depends?).with(mxn1).and_return(true)
+              allow(mxn2).to receive(:term).and_return('mxn2_term')
+            end
+
+            it 'returns dependent mixin' do
+              expect(selectable_object.dependent_term!(mxn1)).to eq 'mxn2_term'
             end
           end
         end

--- a/spec/occi/core/link_spec.rb
+++ b/spec/occi/core/link_spec.rb
@@ -84,8 +84,9 @@ module Occi
       describe '#valid!' do
         context 'with missing required attributes' do
           before do
-            lnk.target = nil
-            lnk.source = nil
+            lnk.target = URI.parse 'http://test/network/1'
+            lnk.source = URI.parse 'http://test/compute/'
+            expect(attributes.values).to all(receive(:valid!))
           end
 
           it 'raises error' do
@@ -95,14 +96,34 @@ module Occi
 
         context 'with all required attributes' do
           before do
-            lnk.target = attributes['occi.core.target']
-            lnk.source = attributes['occi.core.source']
+            lnk.target = URI.parse 'http://test/network/1'
+            lnk.source = URI.parse 'http://test/compute/1'
             expect(attributes.values).to all(receive(:valid!))
           end
 
           it 'passes without error' do
             expect { lnk.valid! }.not_to raise_error
           end
+        end
+      end
+
+      describe '#target_id' do
+        before do
+          lnk.target = URI.parse 'http://test/network/1'
+        end
+
+        it 'returns ID' do
+          expect(lnk.target_id).to eq '1'
+        end
+      end
+
+      describe '#source_id' do
+        before do
+          lnk.source = URI.parse 'http://test/network/1'
+        end
+
+        it 'returns ID' do
+          expect(lnk.source_id).to eq '1'
         end
       end
     end

--- a/spec/occi/core/resource_spec.rb
+++ b/spec/occi/core/resource_spec.rb
@@ -210,6 +210,7 @@ module Occi
       describe '#valid!' do
         context 'with missing required attributes' do
           before do
+            expect(attributes.values).to all(receive(:valid!))
             res.instance_variable_set(:@links, nil)
           end
 
@@ -225,6 +226,93 @@ module Occi
 
           it 'passes without error' do
             expect { res.valid! }.not_to raise_error
+          end
+        end
+      end
+
+      describe '#links_by_kind' do
+        let(:link) { instance_double('Occi::Core::Link') }
+        let(:links) { Set.new([link]) }
+
+        before do
+          res.instance_variable_set(:@links, links)
+        end
+
+        context 'with matches' do
+          before do
+            expect(link).to receive(:kind).and_return(link_kind)
+          end
+
+          it 'returns link(s)' do
+            expect(res.links_by_kind(link_kind)).to include(link)
+          end
+        end
+
+        context 'with no matches' do
+          before do
+            expect(link).to receive(:kind).and_return(kind)
+          end
+
+          it 'returns empty' do
+            expect(res.links_by_kind(link_kind)).to be_empty
+          end
+        end
+      end
+
+      describe '#links_by_kind_identifier' do
+        let(:link) { instance_double('Occi::Core::Link') }
+        let(:links) { Set.new([link]) }
+
+        before do
+          res.instance_variable_set(:@links, links)
+        end
+
+        context 'with matches' do
+          before do
+            expect(link).to receive(:kind_identifier).and_return('bla')
+          end
+
+          it 'returns link(s)' do
+            expect(res.links_by_kind_identifier('bla')).to include(link)
+          end
+        end
+
+        context 'with no matches' do
+          before do
+            expect(link).to receive(:kind_identifier).and_return('meh')
+          end
+
+          it 'returns empty' do
+            expect(res.links_by_kind_identifier('bla')).to be_empty
+          end
+        end
+      end
+
+      describe '#links_by_klass' do
+        let(:link) { instance_double('Occi::Core::Link') }
+        let(:links) { Set.new([link]) }
+
+        before do
+          res.instance_variable_set(:@links, links)
+        end
+
+        context 'with matches' do
+          before do
+            expect(link).to receive(:is_a?).and_return(true)
+          end
+
+          it 'returns link(s)' do
+            expect(res.links_by_klass('bla')).to include(link)
+          end
+        end
+
+        context 'with no matches' do
+          before do
+            expect(link).to receive(:is_a?).and_return(false)
+          end
+
+          it 'returns empty' do
+            expect(res.links_by_klass('bla')).to be_empty
           end
         end
       end


### PR DESCRIPTION
## Changes
* A bunch of helpers for working with mixins and links assigned to `Occi::Core::Entity` sub-type instances
* Improved validation of attributes for `Occi::Core::Entity` sub-type instances (avoiding double-validation, strict URI validation for `occi.core.source` and `occi.core.target`)