### PR TITLE
Added look-up helpers for mixins and links

### DIFF
--- a/lib/occi/infrastructure/compute.rb
+++ b/lib/occi/infrastructure/compute.rb
@@ -4,6 +4,26 @@ module Occi
     # of known instances of the given sub-class. Does not contain any functionality.
     #
     # @author Boris Parak <parak@cesnet.cz>
-    class Compute < Occi::Core::Resource; end
+    class Compute < Occi::Core::Resource
+      # @return [Enumerable] filtered set of links
+      def storagelinks
+        links_by_kind_identifier Occi::Infrastructure::Constants::STORAGELINK_KIND
+      end
+
+      # @return [Enumerable] filtered set of links
+      def networkinterfaces
+        links_by_kind_identifier Occi::Infrastructure::Constants::NETWORKINTERFACE_KIND
+      end
+
+      # @return [Occi::Core::Mixin, NilClass] filtered mixin
+      def os_tpl
+        select_mixin Occi::Infrastructure::Mixins::OsTpl.new
+      end
+
+      # @return [Occi::Core::Mixin, NilClass] filtered mixin
+      def resource_tpl
+        select_mixin Occi::Infrastructure::Mixins::ResourceTpl.new
+      end
+    end
   end
 end

--- a/lib/occi/infrastructure_ext/ipreservation.rb
+++ b/lib/occi/infrastructure_ext/ipreservation.rb
@@ -4,6 +4,11 @@ module Occi
     # of known instances of the given sub-class. Does not contain any functionality.
     #
     # @author Boris Parak <parak@cesnet.cz>
-    class IPReservation < Occi::Infrastructure::Network; end
+    class IPReservation < Occi::Infrastructure::Network
+      # @return [Occi::Core::Mixin, NilClass] filtered mixin
+      def floatingippool
+        select_mixin Occi::InfrastructureExt::Mixins::Floatingippool.new
+      end
+    end
   end
 end

--- a/lib/occi/infrastructure_ext/monkey_island.rb
+++ b/lib/occi/infrastructure_ext/monkey_island.rb
@@ -1,0 +1,1 @@
+Dir[File.join(File.dirname(__FILE__), 'monkey_island', '*.rb')].each { |file| require file.gsub('.rb', '') }

--- a/lib/occi/infrastructure_ext/monkey_island/compute.rb
+++ b/lib/occi/infrastructure_ext/monkey_island/compute.rb
@@ -1,5 +1,6 @@
 module Occi
   module Infrastructure
+    # @see `Occi::Infrastructure::Compute`
     class Compute
       # @return [Enumerable] filtered set of links
       def securitygrouplinks

--- a/lib/occi/infrastructure_ext/monkey_island/compute.rb
+++ b/lib/occi/infrastructure_ext/monkey_island/compute.rb
@@ -1,0 +1,10 @@
+module Occi
+  module Infrastructure
+    class Compute
+      # @return [Enumerable] filtered set of links
+      def securitygrouplinks
+        links_by_kind_identifier Occi::InfrastructureExt::Constants::SECURITY_GROUP_LINK_KIND
+      end
+    end
+  end
+end

--- a/lib/occi/infrastructure_ext/monkey_island/entity.rb
+++ b/lib/occi/infrastructure_ext/monkey_island/entity.rb
@@ -1,5 +1,6 @@
 module Occi
   module Core
+    # @see `Occi::Core::Entity`
     class Entity
       # @return [Occi::Core::Mixin, NilClass] filtered mixin
       def region

--- a/lib/occi/infrastructure_ext/monkey_island/entity.rb
+++ b/lib/occi/infrastructure_ext/monkey_island/entity.rb
@@ -1,0 +1,25 @@
+module Occi
+  module Core
+    class Entity
+      # @return [Occi::Core::Mixin, NilClass] filtered mixin
+      def region
+        select_mixin Occi::InfrastructureExt::Mixins::Region.new
+      end
+
+      # @return [Set] filtered mixins
+      def regions
+        select_mixins Occi::InfrastructureExt::Mixins::Region.new
+      end
+
+      # @return [Occi::Core::Mixin, NilClass] filtered mixin
+      def availability_zone
+        select_mixin Occi::InfrastructureExt::Mixins::AvailabilityZone.new
+      end
+
+      # @return [Set] filtered mixins
+      def availability_zones
+        select_mixins Occi::InfrastructureExt::Mixins::AvailabilityZone.new
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extensions for `Occi::Core::Entity` and `Occi::Infrastructure::Compute` have to be loaded manually using:

```ruby
require 'occi/infrastructure_ext/monkey_island'
```

after `Yell` initialization (to avoid logging errors).